### PR TITLE
feat(cli): add --keepalive option to specify model load duration

### DIFF
--- a/_ollama
+++ b/_ollama
@@ -145,6 +145,7 @@ _ollama() {
                         '--format[Specify the response format]:format:' \
                         '--insecure[Use an insecure registry]' \
                         '--nowordwrap[Disable word wrap]' \
+                        '--keepalive[Duration to keep a model loaded (e.g. 5m)]:duration:' \
                         '--verbose[Show verbose output]' \
                         '*::model and prompt:->model_and_prompt'
                     if [[ $state == model_and_prompt ]]; then


### PR DESCRIPTION
Added a new command line option `--keepalive` to allow users to specify the duration for which a model should remain loaded. This option accepts a duration value (e.g., 5m).