### PR TITLE
feat(completion): allow `show` command without requiring an option

### DIFF
--- a/_ollama
+++ b/_ollama
@@ -163,19 +163,38 @@ _ollama() {
                         '--help[help for create]'
                 ;;
                 show)
-                    if (( CURRENT == 2 )); then
-                        _arguments \
-                            '--license[Show license of a model]' \
-                            '--modelfile[Show Modelfile of a model]' \
-                            '--parameters[Show parameters of a model]' \
-                            '--system[Show system message of a model]' \
-                            '--template[Show template of a model]' \
-                            '-v[Show detailed model information]' \
-                            '--verbose[Show detailed model information]' \
-                            '--help[help for show]'
-                    else
-                        _fetch_ollama_models
-                    fi
+                    local -a show_options=(
+                        '--license[Show license of a model]'
+                        '--modelfile[Show Modelfile of a model]'
+                        '--parameters[Show parameters of a model]'
+                        '--system[Show system message of a model]'
+                        '--template[Show template of a model]'
+                        '-v[Show detailed model information]'
+                        '--verbose[Show detailed model information]'
+                        '--help[Help for show]'
+                    )
+
+                    _arguments -C \
+                        '1:Model:->model' \
+                        '*:Options:->options'
+
+                    case $state in
+                        model)
+                            if [[ "$words[CURRENT]" == -* ]]; then
+                                _values 'options' $show_options
+                            else
+                                _fetch_ollama_models
+                            fi
+                        ;;
+                        options)
+                            # Vérification si une option a déjà été donnée
+                            if (( $#words > 2 )); then
+                                _message "only one option is allowed after model"
+                                return 1
+                            fi
+                            _values 'options' $show_options
+                        ;;
+                    esac
                 ;;
                 run)
                     _arguments \


### PR DESCRIPTION
Refactor the `show` command to enable usage without specifying an option. Modify the command completion logic to support listing models and options separately. Add handling to ensure only one option is selected after specifying a model.